### PR TITLE
Unity2018対応

### DIFF
--- a/Editor/Scripts/InspectorView.cs
+++ b/Editor/Scripts/InspectorView.cs
@@ -120,9 +120,14 @@ namespace Utj.UnityChoseKun
 
 
         public InspectorView() {
-            if (!EditorWindow.HasOpenInstances<PlayerHierarchyWindow>())
+            
+#if UNITY_2019_1_OR_NEWER
+            if (EditorWindow.HasOpenInstances<PlayerHierarchyWindow>())
+#else
+            if (HasOpenInstances<PlayerHierarchyWindow>())
+#endif
             {
-                PlayerHierarchyWindow.Create();
+                    PlayerHierarchyWindow.Create();
             }
             var window = (PlayerHierarchyWindow)EditorWindow.GetWindow(typeof(PlayerHierarchyWindow));
             if (window != null){
@@ -216,7 +221,13 @@ namespace Utj.UnityChoseKun
                 gameObjectKuns.Add(sceneKun.gameObjectKuns[i].instanceID,sceneKun.gameObjectKuns[i]);
             }
 
-            if (!EditorWindow.HasOpenInstances<PlayerHierarchyWindow>())
+
+#if UNITY_2019_1_OR_NEWER
+            if (EditorWindow.HasOpenInstances<PlayerHierarchyWindow>())
+#else
+            if (HasOpenInstances<PlayerHierarchyWindow>())
+#endif
+                
             {
                 PlayerHierarchyWindow.Create();
             }
@@ -254,5 +265,13 @@ namespace Utj.UnityChoseKun
                 choseKunEditorWindow.Repaint();
             }
         }
+
+
+        public static bool HasOpenInstances<T>() where T : UnityEditor.EditorWindow
+        {
+            UnityEngine.Object[] wins = Resources.FindObjectsOfTypeAll(typeof(T));
+            return wins != null && wins.Length > 0;
+        }
+
     }
 }

--- a/Editor/Scripts/PlayerViewEditorWindow.cs
+++ b/Editor/Scripts/PlayerViewEditorWindow.cs
@@ -160,7 +160,12 @@
             RuntimePlatform platform = RuntimePlatform.WindowsEditor;
             Texture2D texture = null;
 
-            if (EditorWindow.HasOpenInstances<UnityChoseKunEditorWindow>()){
+#if UNITY_2019_1_OR_NEWER
+            if (EditorWindow.HasOpenInstances<UnityChoseKunEditorWindow>())
+#else
+            if (HasOpenInstances<UnityChoseKunEditorWindow>())
+#endif
+            {
                 var chosekunEdotorWindow = (UnityChoseKunEditorWindow)EditorWindow.GetWindow(typeof(UnityChoseKunEditorWindow));
                 if (chosekunEdotorWindow != null)
                 {
@@ -519,6 +524,14 @@
         }
 
 
-        
+#if !UNITY_2019_1_OR_NEWER
+
+        public static bool HasOpenInstances<T>() where T : UnityEditor.EditorWindow
+        {
+            UnityEngine.Object[] wins = Resources.FindObjectsOfTypeAll(typeof(T));
+            return wins != null && wins.Length > 0;
+        }
+#endif
+
     }
 }


### PR DESCRIPTION
Unity2018ではEditorWindow.HasOpenInstances()が未実装の為エラーが発生していた不具合を修正しました。