### PR TITLE
Develop

### DIFF
--- a/Player/Scripts/GameObjectKun.cs
+++ b/Player/Scripts/GameObjectKun.cs
@@ -145,17 +145,24 @@
                 gameObject.name = name;
             }
 
-            // ComponentKun側がDirtyであるかいなかはComponentKun側に依存する
-            for(var i = 0; i < componentKunTypes.Length; i++){                        
+            // instanceIDが一致するComponetを探し出してWriteBackを実行する。
+            // ※ComponentKun側がDirtyであるかいなかはGameObjectKunではなく各ComponentKun側に依存する
+            var components = gameObject.GetComponents<Component>();
+            for (var i = 0; i < componentKunTypes.Length; i++){                        
                 var componentKunType = componentKunTypes[i];
                 if(componentKunType == ComponentKun.ComponentKunType.MissingMono)
                 {
                     continue;
+                }                
+                Component component = null;                
+                for(var j = 0; j < components.Length; j++)
+                {                    
+                    if (components[j] != null && components[j].GetInstanceID() == componentKuns[i].instanceID)
+                    {
+                        component = components[j];
+                        break;
+                    }
                 }
-                var systemType = ComponentKun.GetComponentSystemType(componentKunType);                
-                var component = gameObject.GetComponent(systemType);
-                
-                //UnityChoseKun.Log(componentKunType);
 
                 if(component == null){                
                     UnityChoseKun.LogWarning("component == null");

--- a/Player/Scripts/HierarchyPlayer.cs
+++ b/Player/Scripts/HierarchyPlayer.cs
@@ -23,6 +23,7 @@ namespace Utj.UnityChoseKun
         [SerializeField] public int baseID;
         [SerializeField] public PrimitiveType primitiveType;        
         [SerializeField] public string systemType;
+        [SerializeField] public string manifestModule;
 
         public System.Type type;
 
@@ -39,13 +40,15 @@ namespace Utj.UnityChoseKun
             if (type != null)
             {
                 systemType = type.ToString();
+                manifestModule = type.Assembly.ManifestModule.ToString();
             } 
             else
             {
                 systemType = "";
+                manifestModule = "";
             }
             binaryWriter.Write(systemType);
-            //SerializerKun.Serialize(binaryWriter, systemType);
+            binaryWriter.Write(manifestModule);
         }
 
 
@@ -55,27 +58,23 @@ namespace Utj.UnityChoseKun
         /// <param name="binaryReader">BinaryReader</param>
         public virtual void Deserialize(BinaryReader binaryReader)
         {
-            messageID = (MessageID)binaryReader.ReadInt32();
-            //Debug.Log("messageID " + messageID);
-
-            baseID = binaryReader.ReadInt32();
-            //Debug.Log("baseID " + baseID);
-
-            primitiveType = (PrimitiveType)binaryReader.ReadInt32();
-            //Debug.Log("primitiveType " + primitiveType);
-
-            //systemType = SerializerKun.DesirializeString(binaryReader);
-            systemType = binaryReader.ReadString();
-
+            messageID = (MessageID)binaryReader.ReadInt32();            
+            baseID = binaryReader.ReadInt32();            
+            primitiveType = (PrimitiveType)binaryReader.ReadInt32();                        
+            systemType = binaryReader.ReadString();            
+            manifestModule = binaryReader.ReadString();            
             if (!string.IsNullOrEmpty(systemType))
             {
-                //Debug.Log("systemType " + systemType);
-
-                type = System.Type.GetType(systemType);
-
-                //Debug.Log("type "+type);
-            } 
-            
+                if (string.IsNullOrEmpty(manifestModule))
+                {
+                    type = System.Type.GetType(systemType);
+                } 
+                else
+                {
+                    var tmp = systemType + "," + manifestModule;
+                    type = System.Type.GetType(tmp);
+                }
+            }            
         }
 
 
@@ -103,8 +102,11 @@ namespace Utj.UnityChoseKun
             {
                 return false;
             }
-
             if (!type.Equals(other.type))
+            {
+                return false;
+            }
+            if (!manifestModule.Equals(other.manifestModule))
             {
                 return false;
             }


### PR DESCRIPTION
Fixed

1. GameObjectに同じ種類のComponentが複数存在する場合に、Editor側で変更したComponentとは異なるComponentへ反映を行っていた不具合を修正
2. Assembly-CSharp.dll以外のDLLに含まれるClassの生成に失敗していた不具合を修正。(現状ではParticleSystemの生成のみ影響を受けていたと思われる)