### PR TITLE
Fixed Issue#74

### DIFF
--- a/Editor/Scripts/Component/LightView.cs
+++ b/Editor/Scripts/Component/LightView.cs
@@ -408,6 +408,8 @@ namespace Utj.UnityChoseKun
             public void DrawRenderingLayerMask()
             {
 #if UNITY_2019_1_OR_NEWER
+#if !UNITY_6000_0_OR_NEWER
+
                 var srpAsset = Engine.Rendering.GraphicsSettingsKun.currentRenderPipeline;
                 bool usingSRP = srpAsset != null;
                 if (!usingSRP)
@@ -423,6 +425,7 @@ namespace Utj.UnityChoseKun
                 {
                     lightKun.renderingLayerMask = renderingLayerMask;
                 }
+#endif
 #endif
             }
 

--- a/Runtime/Scripts/Component/CameraKun.cs
+++ b/Runtime/Scripts/Component/CameraKun.cs
@@ -406,9 +406,12 @@ namespace  Utj.UnityChoseKun.Engine
             {
                 return false;
             }
-            if(m_sensorSize.Equals(other.m_sensorSize) == false)            
+            if (m_sensorSize != null)
             {
-                return false;
+                if (m_sensorSize.Equals(other.m_sensorSize) == false)
+                {
+                    return false;
+                }
             }
             if (m_lensShift.Equals(other.m_lensShift) == false)
             {

--- a/Runtime/Scripts/Component/ColliderKun.cs
+++ b/Runtime/Scripts/Component/ColliderKun.cs
@@ -27,7 +27,7 @@ namespace Utj.UnityChoseKun.Engine
         /// <summary>
         /// コンストラクタ
         /// </summary>
-        public ColliderKun() : this(null) { }
+        public ColliderKun() : this(null) { m_bounds = new BoundsKun(); material = ""; }
 
 
         /// <summary>

--- a/Runtime/Scripts/Component/LightKun.cs
+++ b/Runtime/Scripts/Component/LightKun.cs
@@ -609,9 +609,12 @@ namespace Utj.UnityChoseKun
                 {
                     return false;
                 }
-                if (mCookie.Equals(otherKun.mCookie) == false)
+                if (mCookie != null)
                 {
-                    return false;
+                    if (mCookie.Equals(otherKun.mCookie) == false)
+                    {
+                        return false;
+                    }
                 }
                 if (mShadows.Equals(otherKun.mShadows) == false)
                 {

--- a/Runtime/Scripts/Component/LightKun.cs
+++ b/Runtime/Scripts/Component/LightKun.cs
@@ -150,7 +150,9 @@ namespace Utj.UnityChoseKun
             LightShadowCasterMode mLightShadowCasterMode;
             int mShadowCustomResolution;
 #if UNITY_2019_1_OR_NEWER
+#if !UNITY_2023_1_OR_NEWER
             LightShape mLightShape;
+#endif
             float mColorTemperature;
             bool mUseColorTemperature;
             int mRenderingLayerMask;
@@ -203,11 +205,13 @@ namespace Utj.UnityChoseKun
 
 
 #if UNITY_2019_1_OR_NEWER
+#if !UNITY_2023_1_OR_NEWER
             public LightShape lightShape
             {
                 get { return mLightShape; }
                 set { mLightShape = value; dirty = true; }
             }
+#endif
             public float colorTemperature
             {
                 get { return mColorTemperature; }
@@ -347,7 +351,9 @@ namespace Utj.UnityChoseKun
                     mShadowCustomResolution = light.shadowCustomResolution;
 
 #if UNITY_2019_1_OR_NEWER
+#if !UNITY_2023_1_OR_NEWER
                     mLightShape = light.shape;
+#endif
                     mUseColorTemperature = light.useColorTemperature;
                     mColorTemperature = light.colorTemperature;
                     mRenderingLayerMask = light.renderingLayerMask;
@@ -399,7 +405,9 @@ namespace Utj.UnityChoseKun
                         light.lightShadowCasterMode = mLightShadowCasterMode;
                         light.shadowCustomResolution = mShadowCustomResolution;
 #if UNITY_2019_1_OR_NEWER
+#if !UNITY_2023_1_OR_NEWER
                         light.shape = mLightShape;
+#endif
                         light.renderingLayerMask = mRenderingLayerMask;
                         light.colorTemperature = mColorTemperature;
                         light.useColorTemperature = mUseColorTemperature;
@@ -453,7 +461,9 @@ namespace Utj.UnityChoseKun
                 binaryWriter.Write((int)mLightShadowCasterMode);
                 binaryWriter.Write(mShadowCustomResolution);
 #if UNITY_2019_1_OR_NEWER
+#if !UNITY_2023_1_OR_NEWER
                 binaryWriter.Write((int)mLightShape);
+#endif
                 binaryWriter.Write(mColorTemperature);
                 binaryWriter.Write(mUseColorTemperature);
                 binaryWriter.Write(mRenderingLayerMask);
@@ -496,7 +506,9 @@ namespace Utj.UnityChoseKun
                 mLightShadowCasterMode = (LightShadowCasterMode)binaryReader.ReadInt32();
                 mShadowCustomResolution = binaryReader.ReadInt32();
 #if UNITY_2019_1_OR_NEWER
+#if !UNITY_2023_1_OR_NEWER
                 mLightShape = (LightShape)binaryReader.ReadInt32();
+#endif
                 mColorTemperature = binaryReader.ReadSingle();
                 mUseColorTemperature = binaryReader.ReadBoolean();
                 mRenderingLayerMask = binaryReader.ReadInt32();
@@ -546,10 +558,12 @@ namespace Utj.UnityChoseKun
                     return false;
                 }
 #if UNITY_2019_1_OR_NEWER
+#if !UNITY_2023_1_OR_NEWER
                 if (mLightShape != otherKun.mLightShape)
                 {
                     return false;
                 }
+#endif
                 if (mColorTemperature.Equals(otherKun.mColorTemperature) == false)
                 {
                     return false;

--- a/Runtime/Scripts/Component/RigidbodyKun.cs
+++ b/Runtime/Scripts/Component/RigidbodyKun.cs
@@ -71,8 +71,8 @@ namespace Utj.UnityChoseKun.Engine
                 rigidbody.linearDamping = linearDamping;
                 rigidbody.angularDamping = angularDamping;
 #else
-                rigidbody.linearDamping = drag;
-                rigidbody.angularDamping = angularDrag;
+                rigidbody.drag = drag;
+                rigidbody.angularDrag = angularDrag;
 #endif
                 rigidbody.useGravity = useGravity;
                 rigidbody.isKinematic = isKinematic;

--- a/Runtime/Scripts/Component/TransformKun.cs
+++ b/Runtime/Scripts/Component/TransformKun.cs
@@ -132,8 +132,12 @@ namespace Utj.UnityChoseKun.Engine
         /// <param name="instanceID"></param>
         /// <returns></returns>
         public Transform GetTransform(int instanceID)
-        {            
+        {
+#if UNITY_2023_1_OR_NEWER
+            var transform = Transform.FindObjectsByType(typeof(Transform),FindObjectsSortMode.None).FirstOrDefault(q => q.GetInstanceID() == instanceID) as Transform;
+#else
             var transform = Transform.FindObjectsOfType<Transform>().FirstOrDefault(q => q.GetInstanceID() == instanceID);
+#endif
             return transform;
         }
 

--- a/Runtime/Scripts/Component/UI/CanvasKun.cs
+++ b/Runtime/Scripts/Component/UI/CanvasKun.cs
@@ -16,7 +16,7 @@ namespace Utj.UnityChoseKun.Engine
         [SerializeField] public int sortingLayerID;
         [SerializeField] public string sortingLayerName;
 
-        public CanvasKun() : this(null) { }
+        public CanvasKun() : this(null) { sortingLayerName = ""; }
 
         public CanvasKun(Component component):base(component)
         {

--- a/Runtime/Scripts/Rendering/RenderPipelineAssetKun.cs
+++ b/Runtime/Scripts/Rendering/RenderPipelineAssetKun.cs
@@ -26,11 +26,9 @@ namespace Utj.UnityChoseKun
             /// </summary>
             public class RenderPipelineAssetKun : ScriptableObjectKun
             {
-                
-
-
+#if !UNITY_6000_0_OR_NEWER
                 [SerializeField] public string[] renderingLayerMaskNames;
-
+#endif
                 [SerializeField] public MaterialKun defaultMaterial;
 
                 [SerializeField] public ShaderKun autodeskInteractiveShader;
@@ -75,7 +73,9 @@ namespace Utj.UnityChoseKun
                 {
                     if (renderPipelineAsset)
                     {
+#if !UNITY_6000_0_OR_NEWER
                         renderingLayerMaskNames = renderPipelineAsset.renderingLayerMaskNames;
+#endif
                         defaultMaterial = new MaterialKun(renderPipelineAsset.defaultMaterial);
                         autodeskInteractiveShader = new ShaderKun(renderPipelineAsset.autodeskInteractiveShader);
                         autodeskInteractiveTransparentShader = new ShaderKun(renderPipelineAsset.autodeskInteractiveTransparentShader);
@@ -105,7 +105,9 @@ namespace Utj.UnityChoseKun
                 public override void Deserialize(BinaryReader binaryReader)
                 {
                     base.Deserialize(binaryReader);
+#if !UNITY_6000_0_OR_NEWER
                     renderingLayerMaskNames = SerializerKun.DesirializeStrings(binaryReader);
+#endif
                     defaultMaterial = SerializerKun.DesirializeObject<MaterialKun>(binaryReader);
                     autodeskInteractiveShader = SerializerKun.DesirializeObject<ShaderKun>(binaryReader);
                     autodeskInteractiveTransparentShader = SerializerKun.DesirializeObject<ShaderKun>(binaryReader);
@@ -129,7 +131,9 @@ namespace Utj.UnityChoseKun
                 public override void Serialize(BinaryWriter binaryWriter)
                 {
                     base.Serialize(binaryWriter);
+#if !UNITY_6000_0_OR_NEWER
                     SerializerKun.Serialize(binaryWriter, renderingLayerMaskNames);
+#endif
                     SerializerKun.Serialize<MaterialKun>(binaryWriter, defaultMaterial);
                     SerializerKun.Serialize<ShaderKun>(binaryWriter, autodeskInteractiveShader);
                     SerializerKun.Serialize<ShaderKun>(binaryWriter, autodeskInteractiveTransparentShader);
@@ -164,11 +168,12 @@ namespace Utj.UnityChoseKun
                     {
                         return false;
                     }
-
+#if !UNITY_6000_0_OR_NEWER
                     if (renderingLayerMaskNames.Length != clone.renderingLayerMaskNames.Length)
                     {
                         return false;
                     }
+
                     for (var i = 0; i < renderingLayerMaskNames.Length; i++)
                     {
                         if (renderingLayerMaskNames[i] != clone.renderingLayerMaskNames[i])
@@ -176,7 +181,7 @@ namespace Utj.UnityChoseKun
                             return false;
                         }
                     }
-
+#endif
 
                     if (defaultMaterial.Equals(clone.defaultMaterial) == false)
                     {

--- a/Runtime/Scripts/Universal RP/UniversalRenderPipelineKun.cs
+++ b/Runtime/Scripts/Universal RP/UniversalRenderPipelineKun.cs
@@ -49,9 +49,13 @@ namespace Utj.UnityChoseKun.Engine.Rendering
 
             public static int maxPerObjectLights
             {
+#if UNITY_2023_1_OR_NEWER
+                get => 8;
+#else
                 // No support to bitfield mask and int[] in gles2. Can't index fast more than 4 lights.
                 // Check Lighting.hlsl for more details.
                 get => (SystemInfoKun.graphicsDeviceType == GraphicsDeviceType.OpenGLES2) ? 4 : 8;
+#endif
             }
 
 

--- a/Tests/Editor/UnityChoseKunTest.cs
+++ b/Tests/Editor/UnityChoseKunTest.cs
@@ -143,8 +143,12 @@ public class UnityChoseKunTest
     [Test]
     public void MaterialKunTest()
     {
-        UnityEditor.SceneManagement.EditorSceneManager.OpenScene("Assets/Scenes/Character Setup.unity");       
+        UnityEditor.SceneManagement.EditorSceneManager.OpenScene("Assets/Scenes/Character Setup.unity");
+#if UNITY_6000_0_OR_NEWER
+        var renderers = UnityEngine.Component.FindObjectsByType<Renderer>(FindObjectsSortMode.None);
+#else
         var renderers = UnityEngine.Component.FindObjectsOfType<Renderer>();
+#endif
         foreach (var renderer in renderers)
         {
             SerializerKunTest<MaterialKun>(new MaterialKun(renderer.sharedMaterial), new MaterialKun());
@@ -191,7 +195,11 @@ public class UnityChoseKunTest
     public void ShaderKunTest()
     {
         UnityEditor.SceneManagement.EditorSceneManager.OpenScene(mTestSceneName);
+#if UNITY_6000_0_OR_NEWER
+        var renderers = UnityEngine.Component.FindObjectsByType<Renderer>(FindObjectsSortMode.None);
+#else
         var renderers = UnityEngine.Component.FindObjectsOfType<Renderer>();
+#endif
         foreach (var renderer in renderers)
         {
             SerializerKunTest<ShaderKun>(new ShaderKun(renderer.sharedMaterial.shader), new ShaderKun());            
@@ -204,7 +212,11 @@ public class UnityChoseKunTest
     {
         UnityEditor.SceneManagement.EditorSceneManager.OpenScene(mTestSceneName);
         var scene = UnityEngine.SceneManagement.SceneManager.GetActiveScene();
+#if UNITY_6000_0_OR_NEWER
+        var transforms = UnityEngine.Component.FindObjectsByType<UnityEngine.Transform>(FindObjectsSortMode.None);
+#else
         var transforms = UnityEngine.Component.FindObjectsOfType<UnityEngine.Transform>();
+#endif
         foreach (var transform in transforms)
         {
             SerializerKunTest<TransformKun>(new TransformKun(transform), new TransformKun());
@@ -215,8 +227,12 @@ public class UnityChoseKunTest
     [Test]
     public void SkinnedMeshRendererKunTest()
     {
-        var scene = UnityEditor.SceneManagement.EditorSceneManager.OpenScene(mTestSceneName);        
+        var scene = UnityEditor.SceneManagement.EditorSceneManager.OpenScene(mTestSceneName);
+#if UNITY_6000_0_OR_NEWER
+        var components = UnityEngine.Component.FindObjectsByType<UnityEngine.SkinnedMeshRenderer>(FindObjectsSortMode.None);
+#else
         var components = UnityEngine.Component.FindObjectsOfType<UnityEngine.SkinnedMeshRenderer>();
+#endif
 
         foreach (var component in components)
         {
@@ -240,8 +256,11 @@ public class UnityChoseKunTest
     public void MeshRendererKunTest()
     {
         var scene = UnityEditor.SceneManagement.EditorSceneManager.OpenScene(mTestSceneName);
+#if UNITY_6000_0_OR_NEWER
+        var meshRendererskinnedMeshRenderer = UnityEngine.Component.FindFirstObjectByType<UnityEngine.MeshRenderer>();
+#else
         var meshRendererskinnedMeshRenderer = UnityEngine.Component.FindObjectOfType<UnityEngine.MeshRenderer>();
-
+#endif
         UnityEngine.Assertions.Assert.IsNotNull(meshRendererskinnedMeshRenderer);
         SerializerKunTest<MeshRendererKun>(new MeshRendererKun(meshRendererskinnedMeshRenderer),new MeshRendererKun());
     }
@@ -257,8 +276,11 @@ public class UnityChoseKunTest
     public void ParticleSystemKunTest()
     {
         var scene = UnityEditor.SceneManagement.EditorSceneManager.OpenScene(mTestSceneName);
+#if UNITY_6000_0_OR_NEWER
+        var components = UnityEngine.Component.FindObjectsByType<UnityEngine.ParticleSystem>(FindObjectsSortMode.None);
+#else
         var components = UnityEngine.Component.FindObjectsOfType<UnityEngine.ParticleSystem>();
-
+#endif
         foreach (var component in components)
         {
             SerializerKunTest<ParticleSystemKun>(new ParticleSystemKun(component), new ParticleSystemKun());

--- a/Tests/UTJ.UnityChoseKun.PlayMode.Tests.asmdef
+++ b/Tests/UTJ.UnityChoseKun.PlayMode.Tests.asmdef
@@ -6,7 +6,9 @@
         "UTJ.UnityChoseKun"
     ],
     "includePlatforms": [],
-    "excludePlatforms": [],
+    "excludePlatforms": [
+        "Editor"
+    ],
     "allowUnsafeCode": false,
     "overrideReferences": true,
     "precompiledReferences": [


### PR DESCRIPTION
- RigidBodyKun:Fixed Issue#74
- LightKun:LightShape is only enabled for versions 2019.1 to 2023.1
- UniversalRenderPipielineKun:Delete GraphicDeveiceType.OpenGLES2 in 2023.1 and later
- TransformKun:Speed ​​up by using FindObjectsByType
- RenderPipelineAssetKun:Obsolute renderingLayerMask in Unity6 and later.This is a temporary measure
- Fixed warnings for some components